### PR TITLE
Avail app context during background tasks by breaking import cycle

### DIFF
--- a/services/web/backend/flask_app/__init__.py
+++ b/services/web/backend/flask_app/__init__.py
@@ -1,0 +1,9 @@
+from . import app
+from . import db
+from . import emails
+from . import modeling
+from . import settings
+from . import utils
+from . import version
+
+__all__ = ["app", "emails", "settings", "utils", "db", "version", "modeling"]

--- a/services/web/backend/flask_app/emails.py
+++ b/services/web/backend/flask_app/emails.py
@@ -112,13 +112,13 @@ Cheers!
         subject="[openFraming] Inference on unlabelled dataset was completed.",
         html_content=(
             """<h2>OpenFraming</h2>
-Hi there!
+Hi there!<br>
 
 You requested to run inference on an unlabelled dataset with the following policy issue
-classifier: {classifier_name}.
+classifier: {classifier_name}.<br>
 
 Inference has completed! Please <a href={predictions_url}>click here</a> to download
-your results.
+your results.<br>
 
 Have a great rest of your day!
 """
@@ -128,15 +128,63 @@ Have a great rest of your day!
         subject="[openFraming] Topic modeling completed.",
         html_content=(
             """<h2>OpenFraming</h2>
-Hi there!
+Hello!<br>
 
 You requested to run topic modeling with your chosen topic model name of:
-{topic_model_name}.
+{topic_model_name}.<br>
 
 Topic modeling has completed! Please <a href={topic_model_preview_url}>click here</a> to
 view your topic modeling results.  On that page, you'll be able to preview the topics
 discovered, and give the topic models names. You'll of course, be able to download the
-results of the topic modeling.
+results of the topic modeling.<br>
+
+Have a great rest of your day!
+"""
+        ),
+    ),
+    "classifier_training_error": EmailTemplate(
+        subject="[openFraming] Error encountered in policy issue classifier training.",
+        html_content=(
+            """<h2>OpenFraming</h2>
+Hello,<br>
+
+The policy issue classifier you started training on openFraming.org has encountered
+an error. The name you gave to this policy issue classifier was: {classifier_name}.<br>
+
+Unfortunately, you'll have to begin training again. If the problem persists, please
+contact us by replying to this email.<br>
+
+Cheers!
+"""
+        ),
+    ),
+    "classifier_inference_errror": EmailTemplate(
+        subject="[openFraming] Error encountered while doing inference on unlabelled dataset.",
+        html_content=(
+            """<h2>OpenFraming</h2>
+Hi there,<br>
+
+You requested to run inference on an unlabelled dataset with the following policy issue
+classifier: {classifier_name}. We ran into an error in processing your submission.<br>
+
+Unfortunately, you'll have to begin this process again again. If the problem persists,
+please contact us by replying to this email.<br>
+
+Have a great rest of your day!
+"""
+        ),
+    ),
+    "topic_model_training_errror": EmailTemplate(
+        subject="[openFraming] Error encountered in topic modeling.",
+        html_content=(
+            """<h2>OpenFraming</h2>
+Hello,<br>
+
+You requested to run topic modeling with your chosen topic model name of:
+{topic_model_name}.<br>
+
+We encountered an internal error in processing your submission. Please try again. If the 
+problem persists, contact us by replying to this email.<br>
 
 Have a great rest of your day!
 """
@@ -226,5 +274,3 @@ class Emailer:
                 sg_client.send(message)
             except Exception as e:
                 logger.critical("Coudn't send email: " + str(vars(e)))
-
-

--- a/services/web/backend/flask_app/modeling/queue_manager.py
+++ b/services/web/backend/flask_app/modeling/queue_manager.py
@@ -1,0 +1,137 @@
+import logging
+import typing as T
+
+import typing_extensions as TT
+from redis import Redis
+from rq import Queue  # type: ignore
+
+from flask_app.settings import Settings
+
+logging.basicConfig()
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.DEBUG)
+
+
+class ClassifierPredictionTaskArgs(TT.TypedDict):
+    task_type: TT.Literal["prediction"]  # This redundancy is for mypy's sake
+    test_set_id: int
+    test_file: str
+    labels: T.List[str]
+    model_path: str
+    cache_dir: str
+    test_output_file: str
+
+
+class ClassifierTrainingTaskArgs(TT.TypedDict):
+    task_type: TT.Literal["training"]
+    classifier_id: int
+    labels: T.List[str]
+    model_path: str
+    cache_dir: str
+    num_train_epochs: float
+    train_file: str
+    dev_file: str
+    output_dir: str
+
+
+class TopicModelTrainingTaskArgs(TT.TypedDict):
+    # No need for task type, since the topic model queue has only one kind of task
+    topic_model_id: int
+    training_file: str
+    num_topics: int
+    fname_keywords: str
+    fname_topics_by_doc: str
+    iterations: int
+    mallet_bin_directory: str
+
+
+class QueueManager(object):
+    def __init__(self) -> None:
+        connection = Redis(host=Settings.REDIS_HOST, port=Settings.REDIS_PORT)
+        is_async = True
+        self.classifiers_queue = Queue(
+            name="classifiers", connection=connection, is_async=is_async
+        )
+        self.topic_models_queue = Queue(
+            name="topic_models", connection=connection, is_async=is_async
+        )
+
+    def add_classifier_training(
+        self,
+        classifier_id: int,
+        labels: T.List[str],
+        model_path: str,
+        train_file: str,
+        dev_file: str,
+        cache_dir: str,
+        output_dir: str,
+        num_train_epochs: float = 3.0,
+    ) -> None:
+        logger.info("Enqueued classifier training")
+
+        self.classifiers_queue.enqueue(
+            "flask_app.modeling.tasks.do_classifier_related_task",
+            ClassifierTrainingTaskArgs(
+                task_type="training",
+                classifier_id=classifier_id,
+                num_train_epochs=num_train_epochs,
+                labels=labels,
+                model_path=model_path,
+                train_file=train_file,
+                dev_file=dev_file,
+                cache_dir=cache_dir,
+                output_dir=output_dir,
+            ),
+            job_timeout=-1,  # This will be popped off by RQ
+        )
+
+    def add_classifier_prediction(
+        self,
+        test_set_id: int,
+        labels: T.List[str],
+        model_path: str,
+        test_file: str,
+        cache_dir: str,
+        test_output_file: str,
+    ) -> None:
+
+        logger.info("Enqueued classifier training.")
+        self.classifiers_queue.enqueue(
+            "flask_app.modeling.tasks.do_classifier_related_task",
+            ClassifierPredictionTaskArgs(
+                test_set_id=test_set_id,
+                task_type="prediction",
+                labels=labels,
+                model_path=model_path,
+                test_file=test_file,
+                cache_dir=cache_dir,
+                test_output_file=test_output_file,
+            ),
+            job_timeout=-1,
+        )
+
+    def add_topic_model_training(
+        self,
+        topic_model_id: int,
+        training_file: str,
+        num_topics: int,
+        fname_keywords: str,
+        fname_topics_by_doc: str,
+        mallet_bin_directory: str,
+        iterations: int = 1000,
+    ) -> None:
+        logger.info("Enqueued lda training with pickle_data.")
+
+        self.topic_models_queue.enqueue(
+            "flask_app.modeling.tasks.do_topic_model_related_task",
+            TopicModelTrainingTaskArgs(
+                topic_model_id=topic_model_id,
+                training_file=training_file,
+                num_topics=num_topics,
+                fname_keywords=fname_keywords,
+                fname_topics_by_doc=fname_topics_by_doc,
+                iterations=iterations,
+                mallet_bin_directory=mallet_bin_directory,
+            ),
+            job_timeout=-1,
+        )

--- a/services/web/backend/flask_app/modeling/tasks.py
+++ b/services/web/backend/flask_app/modeling/tasks.py
@@ -1,16 +1,25 @@
+"""Tasks done in background by Rq.
+
+This file must NOT be imported by app.py, or by any import thereof, because it will cause
+a cyclic import.
+
+The functions within are referred with qualified "Python paths"
+(eg., "flask_app.modeling.tasks.do_classifier_related_task"). Rq supports that.
+"""
 import logging
 import typing as T
 
-import typing_extensions as TT
 from flask import url_for
-from redis import Redis
-from rq import Queue  # type: ignore
 
+import flask_app
 from flask_app import db
 from flask_app import emails
 from flask_app.modeling.classifier import ClassifierModel
 from flask_app.modeling.lda import Corpus
 from flask_app.modeling.lda import LDAModeler
+from flask_app.modeling.queue_manager import ClassifierPredictionTaskArgs
+from flask_app.modeling.queue_manager import ClassifierTrainingTaskArgs
+from flask_app.modeling.queue_manager import TopicModelTrainingTaskArgs
 from flask_app.settings import Settings
 
 logging.basicConfig()
@@ -18,40 +27,7 @@ logger = logging.getLogger(__name__)
 logger.setLevel(logging.DEBUG)
 
 
-class ClassifierPredictionTaskArgs(TT.TypedDict):
-    task_type: TT.Literal["prediction"]  # This redundancy is for mypy's sake
-    test_set_id: int
-    test_file: str
-    labels: T.List[str]
-    model_path: str
-    cache_dir: str
-    test_output_file: str
-
-
-class ClassifierTrainingTaskArgs(TT.TypedDict):
-    task_type: TT.Literal["training"]
-    classifier_id: int
-    labels: T.List[str]
-    model_path: str
-    cache_dir: str
-    num_train_epochs: float
-    train_file: str
-    dev_file: str
-    output_dir: str
-
-
-class TopicModelTrainingTaskArgs(TT.TypedDict):
-    # No need for task type, since the topic model queue has only one kind of task
-    topic_model_id: int
-    training_file: str
-    num_topics: int
-    fname_keywords: str
-    fname_topics_by_doc: str
-    iterations: int
-    mallet_bin_directory: str
-
-
-@db.needs_database_init
+@flask_app.app.needs_app_context
 def do_classifier_related_task(
     task_args: T.Union[ClassifierTrainingTaskArgs, ClassifierPredictionTaskArgs],
 ) -> None:
@@ -135,12 +111,11 @@ def do_classifier_related_task(
             clsf.save()
 
 
-@db.needs_database_init
+@flask_app.app.needs_app_context
 def do_topic_model_related_task(task_args: TopicModelTrainingTaskArgs) -> None:
     topic_mdl = db.TopicModel.get(db.TopicModel.id_ == task_args["topic_model_id"])
     assert topic_mdl.lda_set is not None
     try:
-        print(Settings.__dict__.keys())
         corpus = Corpus(
             file_name=task_args["training_file"],
             content_column_name=Settings.CONTENT_COL,
@@ -171,95 +146,3 @@ def do_topic_model_related_task(task_args: TopicModelTrainingTaskArgs) -> None:
 
     finally:
         topic_mdl.lda_set.save()
-
-
-class Scheduler(object):
-    def __init__(self) -> None:
-        connection = Redis(host=Settings.REDIS_HOST, port=Settings.REDIS_PORT)
-        is_async = True
-        self.classifiers_queue = Queue(
-            name="classifiers", connection=connection, is_async=is_async
-        )
-        self.topic_models_queue = Queue(
-            name="topic_models", connection=connection, is_async=is_async
-        )
-
-    def add_classifier_training(
-        self,
-        classifier_id: int,
-        labels: T.List[str],
-        model_path: str,
-        train_file: str,
-        dev_file: str,
-        cache_dir: str,
-        output_dir: str,
-        num_train_epochs: float = 3.0,
-    ) -> None:
-        logger.info("Enqueued classifier training")
-
-        self.classifiers_queue.enqueue(
-            do_classifier_related_task,
-            ClassifierTrainingTaskArgs(
-                task_type="training",
-                classifier_id=classifier_id,
-                num_train_epochs=num_train_epochs,
-                labels=labels,
-                model_path=model_path,
-                train_file=train_file,
-                dev_file=dev_file,
-                cache_dir=cache_dir,
-                output_dir=output_dir,
-            ),
-            job_timeout=-1,  # This will be popped off by RQ
-        )
-
-    def add_classifier_prediction(
-        self,
-        test_set_id: int,
-        labels: T.List[str],
-        model_path: str,
-        test_file: str,
-        cache_dir: str,
-        test_output_file: str,
-    ) -> None:
-
-        logger.info("Enqueued classifier training.")
-        self.classifiers_queue.enqueue(
-            do_classifier_related_task,
-            ClassifierPredictionTaskArgs(
-                test_set_id=test_set_id,
-                task_type="prediction",
-                labels=labels,
-                model_path=model_path,
-                test_file=test_file,
-                cache_dir=cache_dir,
-                test_output_file=test_output_file,
-            ),
-            job_timeout=-1,
-        )
-
-    def add_topic_model_training(
-        self,
-        topic_model_id: int,
-        training_file: str,
-        num_topics: int,
-        fname_keywords: str,
-        fname_topics_by_doc: str,
-        mallet_bin_directory: str,
-        iterations: int = 1000,
-    ) -> None:
-        logger.info("Enqueued lda training with pickle_data.")
-
-        self.topic_models_queue.enqueue(
-            do_topic_model_related_task,
-            TopicModelTrainingTaskArgs(
-                topic_model_id=topic_model_id,
-                training_file=training_file,
-                num_topics=num_topics,
-                fname_keywords=fname_keywords,
-                fname_topics_by_doc=fname_topics_by_doc,
-                iterations=iterations,
-                mallet_bin_directory=mallet_bin_directory,
-            ),
-            job_timeout=-1,
-        )

--- a/services/web/backend/tests/test_emails.py
+++ b/services/web/backend/tests/test_emails.py
@@ -47,7 +47,6 @@ class TestEmails(AppMixin, unittest.TestCase):
                 topic_model_preview_url="http://www.openframing.org/DOESNTEXISTYET",
             )
         except Exception as e:
-            print(e)
             print(vars(e))
             raise (e)
 


### PR DESCRIPTION
The `app.app_context().push()` was needed to use `url_for()` in a background task. This wasn't possible because importing `flask_app.app` from `flask_app.modeling.scheduler` would have caused a cyclic import. Restructured files a bit to avoid that.

Also added templates for emails to send in case of errors. Not actually sending them right now though.